### PR TITLE
fixed to use function ass_set_line_position 

### DIFF
--- a/libass/ass_render.c
+++ b/libass/ass_render.c
@@ -2133,7 +2133,7 @@ ass_render_event(ASS_Renderer *render_priv, ASS_Event *event,
                 y2scr(render_priv, render_priv->state.clip_y1);
         } else if (valign == VALIGN_SUB) {
             render_priv->state.clip_y0 =
-                y2scr_sub(render_priv, render_priv->state.clip_y0);
+                y2scr_top(render_priv, render_priv->state.clip_y0);
             render_priv->state.clip_y1 =
                 y2scr_sub(render_priv, render_priv->state.clip_y1);
         }

--- a/win32/libass.def
+++ b/win32/libass.def
@@ -37,3 +37,4 @@ ass_add_font            @33
 ass_clear_fonts         @34
 ass_step_sub            @35
 ass_set_shaper          @36
+ass_set_line_position   @37


### PR DESCRIPTION
1. exported function ass_set_line_position so xbmc can call it to set subtitles position use setting "subtitles.align".
   SUBTITLE_ALIGN_BOTTOM_INSIDE
   SUBTITLE_ALIGN_TOP_INSIDE: 
   SUBTITLE_ALIGN_BOTTOM_OUTSIDE
   SUBTITLE_ALIGN_TOP_OUTSIDE
2. fixed wrong clip. this bug let subtitle can't show when set line_position to top and set_use_margins as true.
